### PR TITLE
[feat] further improve the shift signup / unregister flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ yarn dev
 2. generate the migration image `make docker-migration-build`
 3. make sure you have an appropriate `.env` file stored at `./packages/backend/env/.env.docker.local`
 4. start the application with `docker-compose up`
+
+## Design Stuff
+
+The app is primarily powered by MaterialUI. Which is great for everyone that doesnt love doing a bunch of CSS.
+
+I picked this color pallette to give us some additional colors to mess with https://coolors.co/palette/f94144-f3722c-f8961e-f9844a-f9c74f-90be6d-43aa8b-4d908e-577590-277da1.

--- a/packages/backend/controllers/shift.ts
+++ b/packages/backend/controllers/shift.ts
@@ -53,6 +53,20 @@ export default class ShiftController {
     return true;
   }
 
+  public static async RegisterParticipantForShift(
+    shiftID: number,
+    userID: number,
+  ): Promise<boolean> {
+    const query = knex('shift_participants').insert({
+      shiftID,
+      userID,
+    });
+
+    await query;
+
+    return true;
+  }
+
   private static async loadViewModelsFromShifts(
     shifts: Shift[],
   ): Promise<ShiftViewModel[]> {

--- a/packages/backend/controllers/shift.ts
+++ b/packages/backend/controllers/shift.ts
@@ -39,6 +39,20 @@ export default class ShiftController {
     return shiftViewModels;
   }
 
+  public static async UnregisterParticipantFromShift(
+    shiftID: number,
+    userID: number,
+  ): Promise<boolean> {
+    const query = knex('shift_participants')
+      .where('shiftID', shiftID)
+      .andWhere('userID', userID)
+      .del();
+
+    await query;
+
+    return true;
+  }
+
   private static async loadViewModelsFromShifts(
     shifts: Shift[],
   ): Promise<ShiftViewModel[]> {

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -127,6 +127,7 @@ const checkAuthenticated = (
   // eslint-disable-next-line consistent-return
 ) => {
   if (req.isAuthenticated()) {
+    console.log('user is authenticated');
     return next();
   }
   next(createError(401));
@@ -146,5 +147,5 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 app.listen(config.Port, () => {
-  console.log(`Server is Fire at http://localhost:${config.Port}`);
+  console.log(`Server is running at http://localhost:${config.Port}`);
 });

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -127,7 +127,6 @@ const checkAuthenticated = (
   // eslint-disable-next-line consistent-return
 ) => {
   if (req.isAuthenticated()) {
-    console.log('user is authenticated');
     return next();
   }
   next(createError(401));

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -20,13 +20,21 @@ import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import knexConfig from './knexfile';
 import { Config, getConfig } from './config/config';
 
-import User from './models/user/user';
+import AppUser from './models/user/user';
 import authRouter from './routes/auth';
 import indexRouter from './routes/index';
 import usersRouter from './routes/users';
 import schedulesRouter from './routes/schedules';
 import shiftsRouter from './routes/shifts';
 import rostersRouter from './routes/rosters';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface,@typescript-eslint/no-namespace
+    interface User extends AppUser {}
+  }
+}
 
 const envFilePath = process.argv[2];
 
@@ -92,24 +100,28 @@ passport.use(
       callbackURL: config.GoogleOAuthCallbackURL,
     },
     async (accessToken, refreshToken, profile, done) => {
-      const query = User.query();
+      const query = AppUser.query();
       query.where('googleID', profile.id);
       const user = await query;
       if (user.length === 0) {
-        const newUserModel = new User();
+        const newUserModel = new AppUser();
         newUserModel.googleID = profile.id ?? '';
         newUserModel.firstName = profile.name?.givenName ?? '';
         newUserModel.lastName = profile.name?.familyName ?? '';
         newUserModel.email = profile.emails?.[0].value ?? '';
 
-        const innerQuery = User.query().insert(newUserModel);
+        const innerQuery = AppUser.query().insert(newUserModel);
         const newUser = await innerQuery;
-        console.log(newUser);
         return done(null, newUser);
       }
 
-      console.log(profile);
-      return done(null, profile);
+      if (user.length > 1) {
+        return done(
+          new Error('More than one user with the same Google ID was found'),
+        );
+      }
+
+      return done(null, user[0]);
     },
   ),
 );
@@ -126,7 +138,7 @@ const checkAuthenticated = (
   next: NextFunction,
   // eslint-disable-next-line consistent-return
 ) => {
-  if (req.isAuthenticated()) {
+  if (req.isAuthenticated() && req.user.googleID !== '') {
     return next();
   }
   next(createError(401));

--- a/packages/backend/migrations/20231102062655_init.ts
+++ b/packages/backend/migrations/20231102062655_init.ts
@@ -6,7 +6,6 @@ export async function up(knex: Knex): Promise<void> {
     table.string('firstName');
     table.string('lastName');
     table.string('email');
-    table.string('password');
     table.string('googleID');
   });
 }

--- a/packages/backend/migrations/20231122041857_shift_participants.ts
+++ b/packages/backend/migrations/20231122041857_shift_participants.ts
@@ -7,6 +7,7 @@ export async function up(knex: Knex): Promise<void> {
     table.foreign('shiftID').references('id').inTable('shifts');
     table.integer('userID');
     table.foreign('userID').references('id').inTable('users');
+    table.timestamp('created_at').defaultTo(knex.fn.now());
   });
 }
 

--- a/packages/backend/models/requests/user.ts
+++ b/packages/backend/models/requests/user.ts
@@ -1,5 +1,0 @@
-import { Request } from 'express';
-
-export default interface UserRequest extends Request {
-  user?: any;
-}

--- a/packages/backend/models/requests/user.ts
+++ b/packages/backend/models/requests/user.ts
@@ -1,0 +1,5 @@
+import { Request } from 'express';
+
+export default interface UserRequest extends Request {
+  user?: any;
+}

--- a/packages/backend/routes/auth.ts
+++ b/packages/backend/routes/auth.ts
@@ -1,14 +1,11 @@
 import express, { Request, Response, Router } from 'express';
 import passport from 'passport';
+import UserRequest from '../models/requests/user';
 import User from '../models/user/user';
 import { getConfig } from '../config/config';
 
 const config = getConfig();
 const router: Router = express.Router();
-
-interface UserRequest extends Request {
-  user?: any;
-}
 
 router.get('/login/success', async (req: UserRequest, res) => {
   if (req.user && req.isAuthenticated()) {

--- a/packages/backend/routes/auth.ts
+++ b/packages/backend/routes/auth.ts
@@ -1,38 +1,28 @@
 import express, { Request, Response, Router } from 'express';
 import passport from 'passport';
-import UserRequest from '../models/requests/user';
 import User from '../models/user/user';
 import { getConfig } from '../config/config';
 
 const config = getConfig();
 const router: Router = express.Router();
 
-router.get('/login/success', async (req: UserRequest, res) => {
+router.get('/login/success', async (req: Request, res) => {
   if (req.user && req.isAuthenticated()) {
-    const query = User.query().where('googleID', req.user.id);
-
-    const appUsers = await query;
-    if (appUsers.length !== 1) {
-      console.log(
-        `issue querying the DB for the current user... google_id: ${req.user.id}, displayName: ${req.user.displayName} , appUsers.length: ${appUsers.length}`,
-      );
-      res.status(401).json({
-        success: false,
-        message: 'user not authenticated',
-      });
-    }
+    console.log(req.user);
 
     res.status(200).json({
       success: true,
       message: 'successful',
-      user: appUsers[0],
+      user: req.user as User,
     });
-  } else {
-    res.status(401).json({
-      success: false,
-      message: 'user not authenticated',
-    });
+
+    return;
   }
+
+  res.status(401).json({
+    success: false,
+    message: 'user not authenticated',
+  });
 });
 
 router.get(

--- a/packages/backend/routes/auth.ts
+++ b/packages/backend/routes/auth.ts
@@ -8,8 +8,6 @@ const router: Router = express.Router();
 
 router.get('/login/success', async (req: Request, res) => {
   if (req.user && req.isAuthenticated()) {
-    console.log(req.user);
-
     res.status(200).json({
       success: true,
       message: 'successful',

--- a/packages/backend/routes/shifts.ts
+++ b/packages/backend/routes/shifts.ts
@@ -2,7 +2,6 @@ import express, { Request, Response, NextFunction, Router } from 'express';
 import Shift from '../models/shift/shift';
 import User from '../models/user/user';
 import ShiftController from '../controllers/shift';
-import UserRequest from 'models/requests/user';
 
 const router: Router = express.Router();
 
@@ -58,20 +57,21 @@ router.post(
 router.get(
   '/:id/signup',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async (req: UserRequest, res: Response, next: NextFunction) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = req.params;
 
-    const appUser = await User.query().where('googleID', req.user.id).first();
-    if (!appUser) {
+    if (!req.user) {
       res.json({ error: 'User not found' });
       return;
     }
 
-    console.log(`Signing up user ${appUser.id} for shift ${id}`);
+    const user = req.user as User;
+
+    console.log(`Signing up user ${user.id} for shift ${id}`);
 
     const success = await ShiftController.RegisterParticipantForShift(
       parseInt(id, 10),
-      appUser.id,
+      user.id,
     );
 
     if (!success) {
@@ -86,20 +86,20 @@ router.get(
 router.get(
   '/:id/unregister',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async (req: UserRequest, res: Response, next: NextFunction) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     const { id } = req.params;
-
-    const appUser = await User.query().where('googleID', req.user.id).first();
-    if (!appUser) {
+    if (!req.user) {
       res.json({ error: 'User not found' });
       return;
     }
 
-    console.log(`Unregistering user ${appUser.id} from shift ${id}`);
+    const user = req.user as User;
+
+    console.log(`Unregister user ${user.id} from shift ${id}`);
 
     const success = await ShiftController.UnregisterParticipantFromShift(
       parseInt(id, 10),
-      appUser.id,
+      user.id,
     );
 
     if (!success) {

--- a/packages/backend/routes/shifts.ts
+++ b/packages/backend/routes/shifts.ts
@@ -69,7 +69,15 @@ router.get(
 
     console.log(`Signing up user ${appUser.id} for shift ${id}`);
 
-    await Shift.relatedQuery('participants').for(id).relate(appUser.id);
+    const success = await ShiftController.RegisterParticipantForShift(
+      parseInt(id, 10),
+      appUser.id,
+    );
+
+    if (!success) {
+      res.status(500).json({ error: 'Failed to register user for shift' });
+      return;
+    }
     res.json({ success: true });
   },
 );

--- a/packages/backend/view_models/shift.ts
+++ b/packages/backend/view_models/shift.ts
@@ -7,7 +7,7 @@ export default interface ShiftViewModel {
   participants: User[];
 }
 
-export function shiftSignupStatus(
+export function shiftSignUpStatus(
   shiftViewModel: ShiftViewModel,
 ): 'understaffed' | 'staffed' | 'overstaffed' {
   if (

--- a/packages/frontend/src/api/shifts/shifts.ts
+++ b/packages/frontend/src/api/shifts/shifts.ts
@@ -44,7 +44,7 @@ export default class BackendShiftClient implements ShiftClient {
     return data;
   }
 
-  async SignUpUpForShift(shiftID: number): Promise<ShiftViewModel[]> {
+  async SignUpForShift(shiftID: number): Promise<ShiftViewModel[]> {
     const { data } = await axios.get<ShiftViewModel[]>(
       `${this.baseApiURL}/api/shifts/${shiftID}/signup`,
       {

--- a/packages/frontend/src/api/shifts/shifts.ts
+++ b/packages/frontend/src/api/shifts/shifts.ts
@@ -44,6 +44,36 @@ export default class BackendShiftClient implements ShiftClient {
     return data;
   }
 
+  async SignUpUpForShift(shiftID: number): Promise<ShiftViewModel[]> {
+    const { data } = await axios.get<ShiftViewModel[]>(
+      `${this.baseApiURL}/api/shifts/${shiftID}/signup`,
+      {
+        withCredentials: true,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Credentials': 'true',
+        },
+      },
+    );
+    return data;
+  }
+
+  async UnregisterFromShift(shiftID: number): Promise<ShiftViewModel[]> {
+    const { data } = await axios.get<ShiftViewModel[]>(
+      `${this.baseApiURL}/api/shifts/${shiftID}/unregister`,
+      {
+        withCredentials: true,
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Credentials': 'true',
+        },
+      },
+    );
+    return data;
+  }
+
   async GetShiftsByParticipantID(userID: number): Promise<ShiftViewModel[]> {
     if (!userID) {
       console.log('undefined userID, cannot query shifts by participantID');

--- a/packages/frontend/src/components/shifts/ShiftBlock.tsx
+++ b/packages/frontend/src/components/shifts/ShiftBlock.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useRecoilRefresher_UNSTABLE } from 'recoil';
-import { Paper, IconButton } from '@mui/material';
+import { Box, Paper, Popper, IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import ShiftViewModel, {
   shiftSignUpStatus,
   userIsSignedUpForShift,
 } from 'backend/view_models/shift';
+import { TimeOfDayFormatter } from '../../utils/datetime/formatter';
 import CurrentRosterScheduleState from '../../state/schedules';
 import ShiftDetailDialog from './ShiftDetailDialog';
 
@@ -106,6 +107,7 @@ function ShiftBlock(props: RootProps) {
   const refreshSchedules = useRecoilRefresher_UNSTABLE(
     CurrentRosterScheduleState,
   );
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const handleClose = () => {
     setDialogIsOpen(false);
@@ -117,8 +119,25 @@ function ShiftBlock(props: RootProps) {
     setDialogIsOpen(!dialogIsOpen);
   };
 
+  const handlePopperOpen = (event: React.MouseEvent<HTMLElement>) => {
+    if (!isEmptySlot) {
+      setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handlePopperClose = () => {
+    setAnchorEl(null);
+  };
+
+  const popperOpen = Boolean(anchorEl);
+  const id = popperOpen ? 'simple-popper' : undefined;
+
   return (
-    <StyledIconButton onClick={handleClick}>
+    <StyledIconButton
+      onClick={handleClick}
+      onMouseEnter={handlePopperOpen}
+      onMouseLeave={handlePopperClose}
+    >
       <StyledShiftBlock
         shiftViewModel={shiftViewModel}
         timeFrameMinutes={timeFrameMinutes}
@@ -134,6 +153,19 @@ function ShiftBlock(props: RootProps) {
           />
         )}
       </StyledShiftBlock>
+      <Popper
+        id={id}
+        open={popperOpen}
+        anchorEl={anchorEl}
+        onMouseEnter={handlePopperClose}
+      >
+        <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
+          {shiftViewModel &&
+            `${shiftViewModel.scheduleName} -- ${TimeOfDayFormatter.format(
+              shiftViewModel.shift.startTime,
+            )} to ${TimeOfDayFormatter.format(shiftViewModel.shift.endTime)} `}
+        </Box>
+      </Popper>
     </StyledIconButton>
   );
 }

--- a/packages/frontend/src/components/shifts/ShiftBlock.tsx
+++ b/packages/frontend/src/components/shifts/ShiftBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useRecoilRefresher_UNSTABLE } from 'recoil';
 import { Box, Paper, Popper, IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -17,6 +17,8 @@ interface RootProps {
   isEmptySlot?: boolean;
   currentUserID?: number;
 }
+
+const boxStyles = { border: 1, p: 1, bgcolor: 'background.paper' };
 
 const determineBackgroundColor = (
   themeMode: string,
@@ -109,28 +111,41 @@ function ShiftBlock(props: RootProps) {
   );
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setDialogIsOpen(false);
     refreshSchedules();
-  };
+  }, [refreshSchedules, setDialogIsOpen]);
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     console.log('click');
     setDialogIsOpen(!dialogIsOpen);
-  };
+  }, [setDialogIsOpen, dialogIsOpen]);
 
-  const handlePopperOpen = (event: React.MouseEvent<HTMLElement>) => {
-    if (!isEmptySlot) {
-      setAnchorEl(event.currentTarget);
-    }
-  };
+  const handlePopperOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      if (!isEmptySlot) {
+        setAnchorEl(event.currentTarget);
+      }
+    },
+    [setAnchorEl, isEmptySlot],
+  );
 
-  const handlePopperClose = () => {
+  const handlePopperClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, [setAnchorEl]);
 
   const popperOpen = Boolean(anchorEl);
   const id = popperOpen ? 'simple-popper' : undefined;
+
+  const shiftPopperText = useCallback((): string => {
+    if (!shiftViewModel) {
+      return '';
+    }
+
+    return `${shiftViewModel.scheduleName} -- ${TimeOfDayFormatter.format(
+      shiftViewModel.shift.startTime,
+    )} to ${TimeOfDayFormatter.format(shiftViewModel.shift.endTime)}`;
+  }, [shiftViewModel]);
 
   return (
     <StyledIconButton
@@ -159,12 +174,7 @@ function ShiftBlock(props: RootProps) {
         anchorEl={anchorEl}
         onMouseEnter={handlePopperClose}
       >
-        <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
-          {shiftViewModel &&
-            `${shiftViewModel.scheduleName} -- ${TimeOfDayFormatter.format(
-              shiftViewModel.shift.startTime,
-            )} to ${TimeOfDayFormatter.format(shiftViewModel.shift.endTime)} `}
-        </Box>
+        <Box sx={boxStyles}>{shiftPopperText()}</Box>
       </Popper>
     </StyledIconButton>
   );

--- a/packages/frontend/src/components/shifts/ShiftBlock.tsx
+++ b/packages/frontend/src/components/shifts/ShiftBlock.tsx
@@ -105,11 +105,14 @@ function ShiftBlock(props: RootProps) {
     shiftViewModel,
     currentUserID,
   } = props;
+
   const [dialogIsOpen, setDialogIsOpen] = React.useState(false);
   const refreshSchedules = useRecoilRefresher_UNSTABLE(
     CurrentRosterScheduleState,
   );
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const popperOpen = Boolean(anchorEl);
+  const id = popperOpen ? 'simple-popper' : undefined;
 
   const handleClose = useCallback(() => {
     setDialogIsOpen(false);
@@ -117,7 +120,6 @@ function ShiftBlock(props: RootProps) {
   }, [refreshSchedules, setDialogIsOpen]);
 
   const handleClick = useCallback(() => {
-    console.log('click');
     setDialogIsOpen(!dialogIsOpen);
   }, [setDialogIsOpen, dialogIsOpen]);
 
@@ -133,9 +135,6 @@ function ShiftBlock(props: RootProps) {
   const handlePopperClose = useCallback(() => {
     setAnchorEl(null);
   }, [setAnchorEl]);
-
-  const popperOpen = Boolean(anchorEl);
-  const id = popperOpen ? 'simple-popper' : undefined;
 
   const shiftPopperText = useCallback((): string => {
     if (!shiftViewModel) {

--- a/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
+++ b/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useRecoilValue, useRecoilRefresher_UNSTABLE } from 'recoil';
 import { getConfig } from 'backend/config/config';
 import User from 'backend/models/user/user';
@@ -42,19 +42,19 @@ export default function ShiftDetailDialog(props: Props) {
   const { shiftViewModel, isOpen, handleClose } = props;
   const appUser = useRecoilValue(UserState);
 
-  const handleShiftSignup = async () => {
+  const handleShiftSignup = useCallback(async () => {
     const _ = await shiftClient.SignUpUpForShift(shiftViewModel.shift.id);
     setTimeout(() => {
       refreshSchedules();
     }, 200);
-  };
+  }, [shiftViewModel, refreshSchedules]);
 
-  const handleShiftUnregister = async () => {
+  const handleShiftUnregister = useCallback(async () => {
     const _ = await shiftClient.UnregisterFromShift(shiftViewModel.shift.id);
     setTimeout(() => {
       refreshSchedules();
     }, 200);
-  };
+  }, [shiftViewModel, refreshSchedules]);
 
   const generateParticipantList = () => {
     const participantList: JSX.Element[] = [];

--- a/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
+++ b/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
@@ -97,7 +97,7 @@ export default function ShiftDetailDialog(props: Props) {
     if (isSignedUpForThisShift) {
       return (
         <Button autoFocus variant="contained" onClick={handleShiftUnregister}>
-          Unsignup For Shift
+          Unregister From Shift
         </Button>
       );
     }

--- a/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
+++ b/packages/frontend/src/components/shifts/ShiftDetailDialog.tsx
@@ -43,7 +43,7 @@ export default function ShiftDetailDialog(props: Props) {
   const appUser = useRecoilValue(UserState);
 
   const handleShiftSignup = useCallback(async () => {
-    const _ = await shiftClient.SignUpUpForShift(shiftViewModel.shift.id);
+    const _ = await shiftClient.SignUpForShift(shiftViewModel.shift.id);
     setTimeout(() => {
       refreshSchedules();
     }, 200);

--- a/packages/frontend/src/components/shifts/ShiftStack.tsx
+++ b/packages/frontend/src/components/shifts/ShiftStack.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import Schedule from 'backend/models/schedule/schedule';
 import { Stack, Typography } from '@mui/material';
 import Shift from 'backend/models/shift/shift';
@@ -6,6 +7,7 @@ import ShiftViewModel from 'backend/view_models/shift';
 import { getConfig } from 'backend/config/config';
 import BackendShiftClient from 'src/api/shifts/shifts';
 import ShiftBlock from './ShiftBlock';
+import { UserState } from '../../state/store';
 
 const appConfig = getConfig();
 
@@ -18,6 +20,7 @@ export default function ShiftStack(props: Props) {
     () => new BackendShiftClient(appConfig.BackendURL),
     [appConfig.BackendURL],
   );
+  const appUser = useRecoilValue(UserState);
   const { schedule } = props;
   const [shiftViewModels, setShifts] = useState<ShiftViewModel[]>([]);
 
@@ -58,6 +61,7 @@ export default function ShiftStack(props: Props) {
           timeFrameMinutes={shift.getLengthMinutes()}
           shiftViewModel={shiftViewModels[index]}
           key={`shift-block-${index}-${schedule.id}`}
+          currentUserID={appUser.id}
         >
           <Typography variant="caption" display="block">
             ({shiftViewModels[index].participants.length}/

--- a/packages/frontend/src/components/shifts/ShiftStack.tsx
+++ b/packages/frontend/src/components/shifts/ShiftStack.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import Schedule from 'backend/models/schedule/schedule';
-import { Stack, Typography } from '@mui/material';
+import { Paper, Stack, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import Shift from 'backend/models/shift/shift';
 import ShiftViewModel from 'backend/view_models/shift';
 import { getConfig } from 'backend/config/config';
@@ -10,6 +11,15 @@ import ShiftBlock from './ShiftBlock';
 import { UserState } from '../../state/store';
 
 const appConfig = getConfig();
+
+const ShiftHeader = styled(Paper)({
+  color: 'darkslategray',
+  backgroundColor: 'aliceblue',
+  padding: 8,
+  borderRadius: 4,
+  position: 'sticky',
+  top: 0,
+});
 
 interface Props {
   schedule: Schedule;
@@ -77,7 +87,7 @@ export default function ShiftStack(props: Props) {
 
   return (
     <Stack>
-      <ShiftBlock>{schedule.name}</ShiftBlock>
+      <ShiftHeader elevation={3}>{schedule.name}</ShiftHeader>
       {generateShiftBlocks()}
     </Stack>
   );

--- a/packages/frontend/src/pages/Shifts.tsx
+++ b/packages/frontend/src/pages/Shifts.tsx
@@ -17,7 +17,7 @@ export default function Shifts() {
 
   return (
     <Dashboard>
-      <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
+      <Container maxWidth={false} sx={{ mt: 4, mb: 4 }}>
         <ShiftDisplay />
       </Container>
     </Dashboard>

--- a/packages/frontend/src/state/schedules.ts
+++ b/packages/frontend/src/state/schedules.ts
@@ -1,9 +1,22 @@
-import { atom } from 'recoil';
+import { selector } from 'recoil';
 import Schedule from 'backend/models/schedule/schedule';
+import { getConfig } from 'backend/config/config';
+import { CurrentRosterState } from './roster';
+import BackendScheduleClient from '../api/schedules/schedules';
 
-const ScheduleState = atom<Schedule[]>({
-  key: 'scheduleState',
-  default: [],
+const appConfig = getConfig();
+const scheduleClient = new BackendScheduleClient(appConfig.BackendURL);
+
+const CurrentRosterScheduleState = selector<Schedule[]>({
+  key: 'currentRosterScheduleState',
+  get: async ({ get }) => {
+    const roster = get(CurrentRosterState);
+    console.log(
+      `we should eventually only load schedules for a specific roster ${roster.id}`,
+    );
+    const participants = await scheduleClient.GetAllSchedules();
+    return participants;
+  },
 });
 
-export default ScheduleState;
+export default CurrentRosterScheduleState;

--- a/packages/frontend/src/utils/datetime/formatter.ts
+++ b/packages/frontend/src/utils/datetime/formatter.ts
@@ -12,3 +12,14 @@ const options: Intl.DateTimeFormatOptions = {
 const BurningManDateFormatter = new Intl.DateTimeFormat('en-US', options);
 
 export default BurningManDateFormatter;
+
+const timeOfDayOptions: Intl.DateTimeFormatOptions = {
+  timeZone: 'America/Los_Angeles', // Set the timezone to Reno, Nevada (America/Los_Angeles)
+  hour: 'numeric',
+  minute: 'numeric',
+};
+
+export const TimeOfDayFormatter = new Intl.DateTimeFormat(
+  'en-US',
+  timeOfDayOptions,
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR improves the shift signup / unregister flow.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current state of the shift signup isnt exactly functional. It has a bunch of good display stuff. But it doesnt have the workings to actually signup / unregister.

## What steps did you take?
<!--- Please describe what steps were taken to accomplish the PR's goal. -->
1. fix shift signup endpoint
2. add unregister from shift endpoint
3. add timestamp to shift_participants table inorder to track when people have signed up
4. add hover popper to help quickly figure out what the shift you are about to click on is (screenshot down below)
5. add colors to each shift block based on "staffing" state
6. outline any of YOUR shifts in red border
7. make matrix as wide as your screen will allow

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="337" alt="Screenshot 2023-12-13 at 9 26 57 PM" src="https://github.com/campmindshark/people-manager/assets/3021938/fa5cd46e-76d5-4392-af6c-1e2136a7dad6">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
