### PR TITLE
[FIX] missleading display of notifications in the top right nav

### DIFF
--- a/packages/backend/view_models/signup_status.ts
+++ b/packages/backend/view_models/signup_status.ts
@@ -26,4 +26,30 @@ export const NewPlaceholderSignupStatus = (): SignupStatus => ({
   shiftCount: 0,
 });
 
+export const signupStatusIssues = (status: SignupStatus): string[] => {
+  const issues: string[] = [];
+
+  if (!status.hasSignedUpForRoster) {
+    issues.push('You have not signed up for this roster.');
+  }
+
+  if (!status.hasCompletedPrivateProfile) {
+    issues.push('You have not completed your private profile.');
+  }
+
+  if (!status.hasCompletedPublicProfile) {
+    issues.push('You have not completed your public profile.');
+  }
+
+  if (!status.hasPaidDues) {
+    issues.push('You have not paid your dues.');
+  }
+
+  if (!status.isVerified) {
+    issues.push('You have not been verified.');
+  }
+
+  return issues;
+};
+
 export default SignupStatus;

--- a/packages/frontend/src/layouts/dashboard/TopBar.tsx
+++ b/packages/frontend/src/layouts/dashboard/TopBar.tsx
@@ -1,12 +1,24 @@
-import * as React from 'react';
-import { Avatar, Badge, IconButton, Typography, Toolbar } from '@mui/material';
+import React, { useCallback } from 'react';
+import {
+  Avatar,
+  Badge,
+  Box,
+  IconButton,
+  Popper,
+  Typography,
+  Toolbar,
+} from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import LogoutIcon from '@mui/icons-material/Logout';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { useRecoilValue } from 'recoil';
+import { signupStatusIssues } from 'backend/view_models/signup_status';
 import { getFrontendConfig } from '../../config/config';
 import AppBar from './AppBar';
-import PageState, { UserState } from '../../state/store';
+import PageState, {
+  UserState,
+  CurrentUserSignupStatus,
+} from '../../state/store';
 
 const frontendConfig = getFrontendConfig();
 
@@ -18,6 +30,23 @@ interface TopBarProps {
 export default function TopBar({ open, toggleDrawer }: TopBarProps) {
   const pageState = useRecoilValue(PageState);
   const appUser = useRecoilValue(UserState);
+  const signupStatus = useRecoilValue(CurrentUserSignupStatus);
+  const issues = signupStatusIssues(signupStatus);
+
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const popperOpen = Boolean(anchorEl);
+  const id = popperOpen ? 'simple-popper' : undefined;
+
+  const handlePopperOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [setAnchorEl],
+  );
+
+  const handlePopperClose = useCallback(() => {
+    setAnchorEl(null);
+  }, [setAnchorEl]);
 
   const handleLogout = () => {
     console.log('logout');
@@ -56,8 +85,8 @@ export default function TopBar({ open, toggleDrawer }: TopBarProps) {
           {appUser.firstName[0]}
           {appUser.lastName[0]}
         </Avatar>
-        <IconButton color="inherit">
-          <Badge badgeContent={4} color="secondary">
+        <IconButton color="inherit" onClick={handlePopperOpen}>
+          <Badge badgeContent={issues.length} color="secondary">
             <NotificationsIcon />
           </Badge>
         </IconButton>
@@ -65,6 +94,19 @@ export default function TopBar({ open, toggleDrawer }: TopBarProps) {
           <LogoutIcon />
         </IconButton>
       </Toolbar>
+      <Popper
+        id={id}
+        open={popperOpen}
+        anchorEl={anchorEl}
+        onMouseEnter={handlePopperClose}
+        sx={{ zIndex: 9999 }}
+      >
+        <Box sx={{ border: 1, p: 1, bgcolor: 'background.paper' }}>
+          {issues.map((issue) => (
+            <Typography key={issue}>{issue}</Typography>
+          ))}
+        </Box>
+      </Popper>
     </AppBar>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As @Ashoat pointed out, the notifications in the top right navbar were a bit confusing. This PR makes them actually mean something. Now notifications will be displayed for the number of signupstatus things you are missing. It will also give a text hint as to what is not completed.
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What steps did you take?

<!--- Please describe what steps were taken to accomplish the PR's goal. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
