### PR TITLE
fix: cert loading for migration dockerimage

### DIFF
--- a/docker/Dockerfile.migration
+++ b/docker/Dockerfile.migration
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 RUN apk update && apk add bash curl
 
 RUN mkdir -p /usr/local/certs/ca-certificates
-RUN curl -ks 'https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem' -o '/usr/local/certs/ca-certificates/rds-ca-2015-root.pem'
+RUN curl -ks 'https://truststore.pki.rds.amazonaws.com/us-west-2/us-west-2-bundle.pem' -o '/usr/local/certs/ca-certificates/us-west-2-bundle.pem'
 
 # Install app dependencies
 COPY . .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the certs to the main image but not the migration image. This broke the ecs task.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## What steps did you take?

<!--- Please describe what steps were taken to accomplish the PR's goal. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
