### PR TITLE
feat: Add admin-configurable active roster

### DIFF
--- a/.github/workflows/run-migration-task.yml
+++ b/.github/workflows/run-migration-task.yml
@@ -1,0 +1,73 @@
+name: Run ECS Migration Task
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-migration-task:
+    name: Run Migration Task
+    runs-on: ubuntu-latest
+    environment: production
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: Run ECS migration task
+        run: |
+          set -euo pipefail
+
+          CLUSTER_NAME="people-manager-cluster"
+          SERVICE_NAME="people-manager-service"
+          MIGRATION_TASK_FAMILY="people-manager-db-migration-task"
+
+          SUBNETS=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets' \
+            --output text | tr '\t' ',')
+
+          SECURITY_GROUPS=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.securityGroups' \
+            --output text | tr '\t' ',')
+
+          ASSIGN_PUBLIC_IP=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp' \
+            --output text)
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER_NAME" \
+            --launch-type FARGATE \
+            --task-definition "$MIGRATION_TASK_FAMILY" \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=$ASSIGN_PUBLIC_IP}" \
+            --count 1 \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          aws ecs wait tasks-stopped --cluster "$CLUSTER_NAME" --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "$CLUSTER_NAME" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "Migration task failed with exit code: $EXIT_CODE"
+            exit 1
+          fi

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -60,3 +60,63 @@ jobs:
           TF_VAR_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           TF_LOG: info
         run: terraform apply -auto-approve
+
+      - name: Detect migration file changes
+        id: migration_changes
+        run: |
+          set -euo pipefail
+
+          if git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | rg '^packages/backend/migrations/'; then
+            echo "run_migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ECS migration task
+        if: steps.migration_changes.outputs.run_migrations == 'true'
+        run: |
+          set -euo pipefail
+
+          CLUSTER_NAME="people-manager-cluster"
+          SERVICE_NAME="people-manager-service"
+          MIGRATION_TASK_FAMILY="people-manager-db-migration-task"
+
+          SUBNETS=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets' \
+            --output json | jq -r 'join(",")')
+
+          SECURITY_GROUPS=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.securityGroups' \
+            --output json | jq -r 'join(",")')
+
+          ASSIGN_PUBLIC_IP=$(aws ecs describe-services \
+            --cluster "$CLUSTER_NAME" \
+            --services "$SERVICE_NAME" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp' \
+            --output text)
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER_NAME" \
+            --launch-type FARGATE \
+            --task-definition "$MIGRATION_TASK_FAMILY" \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUPS],assignPublicIp=$ASSIGN_PUBLIC_IP}" \
+            --count 1 \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          aws ecs wait tasks-stopped --cluster "$CLUSTER_NAME" --tasks "$TASK_ARN"
+
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "$CLUSTER_NAME" \
+            --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "Migration task failed with exit code: $EXIT_CODE"
+            exit 1
+          fi

--- a/packages/backend/index.ts
+++ b/packages/backend/index.ts
@@ -32,6 +32,7 @@ import rosterParticipantsRouter from './routes/roster_participants';
 import groupRouter from './routes/groups';
 import duesRouter from './routes/dues';
 import devAuthRouter from './routes/dev_auth';
+import settingsRouter from './routes/settings';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -207,6 +208,7 @@ app.use(
 );
 app.use('/api/groups', checkAuthenticated, groupRouter);
 app.use('/api/dues', checkAuthenticated, duesRouter);
+app.use('/api/settings', checkAuthenticated, settingsRouter);
 
 app.use('/api/health', (req: Request, res: Response) => {
   res.status(200).send('healthy');

--- a/packages/backend/migrations/20260403000000_app_settings.ts
+++ b/packages/backend/migrations/20260403000000_app_settings.ts
@@ -1,12 +1,17 @@
 import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.createTable('app_settings', (table) => {
+  await knex.schema.createTable('app_settings', (table) => {
     table.increments('id').primary();
     table.string('key').unique().notNullable();
     table.string('value').notNullable();
     table.timestamps(true, true);
   });
+
+  await knex('app_settings')
+    .insert({ key: 'active_roster_id', value: '2' })
+    .onConflict('key')
+    .ignore();
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/packages/backend/migrations/20260403000000_app_settings.ts
+++ b/packages/backend/migrations/20260403000000_app_settings.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable('app_settings', (table) => {
+    table.increments('id').primary();
+    table.string('key').unique().notNullable();
+    table.string('value').notNullable();
+    table.timestamps(true, true);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists('app_settings');
+}

--- a/packages/backend/models/app_setting/app_setting.ts
+++ b/packages/backend/models/app_setting/app_setting.ts
@@ -1,0 +1,22 @@
+import { Model } from 'objection';
+
+export default class AppSetting extends Model {
+  id!: number;
+
+  key!: string;
+
+  value!: string;
+
+  static tableName = 'app_settings';
+
+  static jsonSchema = {
+    type: 'object',
+    required: ['key', 'value'],
+
+    properties: {
+      id: { type: 'integer' },
+      key: { type: 'string', minLength: 1, maxLength: 255 },
+      value: { type: 'string', minLength: 1, maxLength: 255 },
+    },
+  };
+}

--- a/packages/backend/roles/config.json
+++ b/packages/backend/roles/config.json
@@ -25,7 +25,8 @@
         "users:block",
         "users:readAll",
         "userVerification:edit",
-        "userVerification:readAll"
+        "userVerification:readAll",
+        "settings:edit"
       ]
     }
   ]

--- a/packages/backend/routes/settings.ts
+++ b/packages/backend/routes/settings.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response, Router } from 'express';
+import AppSetting from '../models/app_setting/app_setting';
+import Roster from '../models/roster/roster';
+import hasPermission from '../middleware/rbac';
+
+const router: Router = express.Router();
+
+router.get('/active-roster', async (_req: Request, res: Response) => {
+  try {
+    const setting = await AppSetting.query()
+      .where({ key: 'active_roster_id' })
+      .first();
+
+    if (!setting) {
+      return res.status(404).json({ error: 'Active roster setting not found' });
+    }
+
+    return res.json({ activeRosterID: parseInt(setting.value, 10) });
+  } catch (error) {
+    console.error('Error fetching active roster setting:', error);
+    return res
+      .status(500)
+      .json({ error: 'Failed to fetch active roster setting' });
+  }
+});
+
+router.put(
+  '/active-roster',
+  hasPermission('settings:edit'),
+  async (req: Request, res: Response) => {
+    try {
+      const { activeRosterID } = req.body;
+
+      if (!activeRosterID || Number.isNaN(parseInt(activeRosterID, 10))) {
+        return res
+          .status(400)
+          .json({ error: 'Valid activeRosterID is required' });
+      }
+
+      const rosterID = parseInt(activeRosterID, 10);
+
+      const roster = await Roster.query().findById(rosterID);
+      if (!roster) {
+        return res
+          .status(404)
+          .json({ error: `Roster with ID ${rosterID} does not exist` });
+      }
+
+      const updated = await AppSetting.query()
+        .where({ key: 'active_roster_id' })
+        .patch({ value: String(rosterID) })
+        .returning('*');
+
+      if (!updated) {
+        return res
+          .status(404)
+          .json({ error: 'Active roster setting not found' });
+      }
+
+      return res.json({ activeRosterID: rosterID });
+    } catch (error) {
+      console.error('Error updating active roster setting:', error);
+      return res
+        .status(500)
+        .json({ error: 'Failed to update active roster setting' });
+    }
+  },
+);
+
+export default router;

--- a/packages/backend/routes/settings.ts
+++ b/packages/backend/routes/settings.ts
@@ -4,12 +4,24 @@ import Roster from '../models/roster/roster';
 import hasPermission from '../middleware/rbac';
 
 const router: Router = express.Router();
+const ActiveRosterSettingKey = 'active_roster_id';
+
+async function ensureActiveRosterSetting(): Promise<AppSetting | undefined> {
+  await AppSetting.query()
+    .insert({ key: ActiveRosterSettingKey, value: '2' })
+    .onConflict('key')
+    .ignore();
+
+  const setting = await AppSetting.query()
+    .where({ key: ActiveRosterSettingKey })
+    .first();
+
+  return setting;
+}
 
 router.get('/active-roster', async (_req: Request, res: Response) => {
   try {
-    const setting = await AppSetting.query()
-      .where({ key: 'active_roster_id' })
-      .first();
+    const setting = await ensureActiveRosterSetting();
 
     if (!setting) {
       return res.status(404).json({ error: 'Active roster setting not found' });
@@ -30,14 +42,15 @@ router.put(
   async (req: Request, res: Response) => {
     try {
       const { activeRosterID } = req.body;
+      const parsedActiveRosterID = parseInt(activeRosterID, 10);
 
-      if (!activeRosterID || Number.isNaN(parseInt(activeRosterID, 10))) {
+      if (Number.isNaN(parsedActiveRosterID)) {
         return res
           .status(400)
           .json({ error: 'Valid activeRosterID is required' });
       }
 
-      const rosterID = parseInt(activeRosterID, 10);
+      const rosterID = parsedActiveRosterID;
 
       const roster = await Roster.query().findById(rosterID);
       if (!roster) {
@@ -46,16 +59,10 @@ router.put(
           .json({ error: `Roster with ID ${rosterID} does not exist` });
       }
 
-      const updated = await AppSetting.query()
-        .where({ key: 'active_roster_id' })
-        .patch({ value: String(rosterID) })
-        .returning('*');
-
-      if (!updated) {
-        return res
-          .status(404)
-          .json({ error: 'Active roster setting not found' });
-      }
+      await AppSetting.query()
+        .insert({ key: ActiveRosterSettingKey, value: String(rosterID) })
+        .onConflict('key')
+        .merge({ value: String(rosterID) });
 
       return res.json({ activeRosterID: rosterID });
     } catch (error) {

--- a/packages/backend/seeds/app-settings.ts
+++ b/packages/backend/seeds/app-settings.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/prefer-default-export */
+import { Knex } from 'knex';
+
+async function upsertSetting(
+  knex: Knex,
+  setting: { key: string; value: string },
+): Promise<void> {
+  const existing = await knex('app_settings')
+    .where({ key: setting.key })
+    .first();
+  if (!existing) {
+    await knex('app_settings').insert(setting);
+  }
+}
+
+export async function seed(knex: Knex): Promise<void> {
+  await upsertSetting(knex, { key: 'active_roster_id', value: '2' });
+}

--- a/packages/frontend/src/api/settings/client.ts
+++ b/packages/frontend/src/api/settings/client.ts
@@ -1,0 +1,31 @@
+import axios from 'axios';
+import defaultRequestConfig from '../common/requestConfig';
+
+interface ActiveRosterResponse {
+  activeRosterID: number;
+}
+
+export default class BackendSettingsClient {
+  baseApiURL: string;
+
+  constructor(baseApiURL: string) {
+    this.baseApiURL = baseApiURL;
+  }
+
+  async GetActiveRosterID(): Promise<number> {
+    const { data } = await axios.get<ActiveRosterResponse>(
+      `${this.baseApiURL}/api/settings/active-roster`,
+      defaultRequestConfig,
+    );
+    return data.activeRosterID;
+  }
+
+  async SetActiveRosterID(rosterID: number): Promise<number> {
+    const { data } = await axios.put<ActiveRosterResponse>(
+      `${this.baseApiURL}/api/settings/active-roster`,
+      { activeRosterID: rosterID },
+      defaultRequestConfig,
+    );
+    return data.activeRosterID;
+  }
+}

--- a/packages/frontend/src/components/RosterSignupForm.tsx
+++ b/packages/frontend/src/components/RosterSignupForm.tsx
@@ -3,9 +3,10 @@ import validator from '@rjsf/validator-ajv8';
 import Form from '@rjsf/mui';
 import RosterParticipant from 'backend/models/roster_participant/roster_participant';
 import Snackbar from '@mui/material/Snackbar';
+import { useRecoilValue } from 'recoil';
 import BackendRosterClient from 'src/api/roster/roster';
 
-import { CurrentRosterID } from 'src/state/roster';
+import { ActiveRosterIDState } from 'src/state/roster';
 import { getFrontendConfig } from '../config/config';
 import './css/form.css';
 
@@ -22,6 +23,7 @@ function RosterSignupForm(props: Props) {
     rosterParticipantProp,
   );
   const [open, setOpen] = React.useState(false);
+  const activeRosterID = useRecoilValue(ActiveRosterIDState);
 
   const rosterClient = useMemo(
     () => new BackendRosterClient(frontendConfig.BackendURL),
@@ -43,7 +45,7 @@ function RosterSignupForm(props: Props) {
   const handleSubmit = async (data: any) => {
     const { formData } = data as { formData: RosterParticipant };
 
-    const updatedUser = await rosterClient.Signup(CurrentRosterID, formData);
+    const updatedUser = await rosterClient.Signup(activeRosterID, formData);
     setRosterParticipant(updatedUser);
     handleSuccess();
     setOpen(true);

--- a/packages/frontend/src/components/RosterSignupFormV2.tsx
+++ b/packages/frontend/src/components/RosterSignupFormV2.tsx
@@ -18,6 +18,7 @@ import {
 import { DateTimePicker } from '@mui/x-date-pickers';
 import RosterParticipant from 'backend/models/roster_participant/roster_participant';
 import { CurrentUserSignupStatus } from '../state/store';
+import { ActiveRosterIDState } from '../state/roster';
 import { getFrontendConfig } from '../config/config';
 import BackendRosterClient from '../api/roster/roster';
 
@@ -78,11 +79,15 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
   });
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const userSignupStatus = useRecoilValue(CurrentUserSignupStatus);
+  const activeRosterID = useRecoilValue(ActiveRosterIDState);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await rosterClient.Signup(2, formData as unknown as RosterParticipant);
+      await rosterClient.Signup(
+        activeRosterID,
+        formData as unknown as RosterParticipant,
+      );
       setSnackbarOpen(true);
       if (
         !userSignupStatus.hasCompletedPrivateProfile ||

--- a/packages/frontend/src/pages/Admin.tsx
+++ b/packages/frontend/src/pages/Admin.tsx
@@ -1,19 +1,43 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
-import { Typography } from '@mui/material';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Alert,
+  SelectChangeEvent,
+} from '@mui/material';
+import Roster from 'backend/models/roster/roster';
+import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
 import Dashboard from '../layouts/dashboard/Dashboard';
 import PageState, { MyRolesState } from '../state/store';
+import { ActiveRosterIDState } from '../state/roster';
 import AllParticipantUserSignupStateTable from '../components/AllParticipantUserSignupStateTable';
 import VerifyUsersTable from '../components/VerifyUsersTable';
 import GroupManagementTable from '../components/admin/GroupManagementTable';
 import RosterParticipantCSVDownloadBtn from '../components/admin/RosterParticipantCSVDownloadBtn';
+import BackendRosterClient from '../api/roster/roster';
+import BackendSettingsClient from '../api/settings/client';
+import { getFrontendConfig } from '../config/config';
+
+const frontendConfig = getFrontendConfig();
+const rosterClient = new BackendRosterClient(frontendConfig.BackendURL);
+const settingsClient = new BackendSettingsClient(frontendConfig.BackendURL);
 
 export default function Admin() {
   const setPageState = useSetRecoilState(PageState);
   const myRoles = useRecoilValue(MyRolesState);
+  const [activeRosterID, setActiveRosterID] =
+    useRecoilState(ActiveRosterIDState);
+  const [rosters, setRosters] = useState<Roster[]>([]);
+  const [rosterMessage, setRosterMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
 
   useEffect(() => {
     setPageState({
@@ -22,10 +46,66 @@ export default function Admin() {
     });
   });
 
+  useEffect(() => {
+    rosterClient.GetAllRosters().then(setRosters).catch(console.error);
+  }, []);
+
+  const handleRosterChange = async (event: SelectChangeEvent<number>) => {
+    const newRosterID = Number(event.target.value);
+    try {
+      await settingsClient.SetActiveRosterID(newRosterID);
+      setActiveRosterID(newRosterID);
+      setRosterMessage({
+        type: 'success',
+        text: `Active roster changed to ID ${newRosterID}. Users will see this on their next page load.`,
+      });
+    } catch (error) {
+      setRosterMessage({
+        type: 'error',
+        text: `Failed to update active roster: ${error}`,
+      });
+    }
+  };
+
   return (
     <Dashboard>
       <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
         <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <Paper sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
+              <h1>Active Roster</h1>
+              <Typography sx={{ mb: 2 }}>
+                Changing this affects which roster all users see when they load
+                the site.
+              </Typography>
+              {rosterMessage && (
+                <Alert
+                  severity={rosterMessage.type}
+                  sx={{ mb: 2 }}
+                  onClose={() => setRosterMessage(null)}
+                >
+                  {rosterMessage.text}
+                </Alert>
+              )}
+              <FormControl sx={{ minWidth: 200, maxWidth: 400 }}>
+                <InputLabel id="active-roster-select-label">
+                  Active Roster
+                </InputLabel>
+                <Select
+                  labelId="active-roster-select-label"
+                  value={activeRosterID}
+                  label="Active Roster"
+                  onChange={handleRosterChange}
+                >
+                  {rosters.map((roster) => (
+                    <MenuItem key={roster.id} value={roster.id}>
+                      {roster.year} (ID: {roster.id})
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Paper>
+          </Grid>
           <Grid item xs={12} md={8} lg={9}>
             <Paper
               sx={{

--- a/packages/frontend/src/pages/AdminUserManagement.tsx
+++ b/packages/frontend/src/pages/AdminUserManagement.tsx
@@ -25,7 +25,7 @@ import Dashboard from '../layouts/dashboard/Dashboard';
 import PageState from '../state/store';
 import {
   CurrentRosterParticipantsDetailedState,
-  CurrentRosterID,
+  ActiveRosterIDState,
 } from '../state/roster';
 import BackendRosterClient from '../api/roster/roster';
 import { getFrontendConfig } from '../config/config';
@@ -36,6 +36,7 @@ const rosterClient = new BackendRosterClient(frontendConfig.BackendURL);
 export default function AdminUserManagement() {
   const setPageState = useSetRecoilState(PageState);
   const participants = useRecoilValue(CurrentRosterParticipantsDetailedState);
+  const activeRosterID = useRecoilValue(ActiveRosterIDState);
   const [selectedUsers, setSelectedUsers] = useState<number[]>([]);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [userToRemove, setUserToRemove] = useState<number | null>(null);
@@ -73,7 +74,7 @@ export default function AdminUserManagement() {
     setLoading(true);
     setMessage(null);
     try {
-      await rosterClient.RemoveUserFromRoster(CurrentRosterID, userId);
+      await rosterClient.RemoveUserFromRoster(activeRosterID, userId);
       setMessage({ type: 'success', text: 'User removed successfully' });
       setConfirmDialogOpen(false);
       setUserToRemove(null);
@@ -92,7 +93,7 @@ export default function AdminUserManagement() {
     setMessage(null);
     try {
       const result = await rosterClient.RemoveUsersFromRoster(
-        CurrentRosterID,
+        activeRosterID,
         selectedUsers,
       );
       setMessage({

--- a/packages/frontend/src/state/roster.ts
+++ b/packages/frontend/src/state/roster.ts
@@ -1,4 +1,4 @@
-import { selector } from 'recoil';
+import { atom, selector } from 'recoil';
 import Roster from 'backend/models/roster/roster';
 import SignupStatus from 'backend/view_models/signup_status';
 import RosterParticipantViewModel, {
@@ -6,16 +6,30 @@ import RosterParticipantViewModel, {
 } from 'backend/view_models/roster_participant';
 import { getFrontendConfig } from '../config/config';
 import BackendRosterClient from '../api/roster/roster';
+import BackendSettingsClient from '../api/settings/client';
 
 const frontendConfig = getFrontendConfig();
 const rosterClient = new BackendRosterClient(frontendConfig.BackendURL);
+const settingsClient = new BackendSettingsClient(frontendConfig.BackendURL);
 
-export const CurrentRosterID = 2;
+const ActiveRosterIDDefault = selector<number>({
+  key: 'activeRosterIDDefault',
+  get: async () => {
+    const activeRosterID = await settingsClient.GetActiveRosterID();
+    return activeRosterID;
+  },
+});
+
+export const ActiveRosterIDState = atom<number>({
+  key: 'activeRosterID',
+  default: ActiveRosterIDDefault,
+});
 
 export const CurrentRosterState = selector<Roster>({
   key: 'currentRoster',
-  get: async () => {
-    const roster = await rosterClient.GetRosterByID(CurrentRosterID);
+  get: async ({ get }) => {
+    const activeRosterID = get(ActiveRosterIDState);
+    const roster = await rosterClient.GetRosterByID(activeRosterID);
     return roster;
   },
 });

--- a/packages/frontend/src/state/roster.ts
+++ b/packages/frontend/src/state/roster.ts
@@ -15,8 +15,28 @@ const settingsClient = new BackendSettingsClient(frontendConfig.BackendURL);
 const ActiveRosterIDDefault = selector<number>({
   key: 'activeRosterIDDefault',
   get: async () => {
-    const activeRosterID = await settingsClient.GetActiveRosterID();
-    return activeRosterID;
+    try {
+      const activeRosterID = await settingsClient.GetActiveRosterID();
+      return activeRosterID;
+    } catch (error) {
+      console.error(
+        'Failed to load active roster from settings API, falling back to latest roster by year:',
+        error,
+      );
+
+      const rosters = await rosterClient.GetAllRosters();
+      if (rosters.length === 0) {
+        throw new Error(
+          'No rosters found while resolving fallback active roster ID',
+        );
+      }
+
+      const fallbackRoster = rosters.reduce((latestRoster, roster) =>
+        roster.year > latestRoster.year ? roster : latestRoster,
+      );
+
+      return fallbackRoster.id;
+    }
   },
 });
 


### PR DESCRIPTION
## Description

Replace the hardcoded `CurrentRosterID = 2` with a DB-backed setting that admins can change at runtime via the Admin page. The active roster ID is stored in a new `app_settings` table and served through a new `/api/settings/active-roster` endpoint.

## Motivation and Context

The active roster was hardcoded in the frontend, requiring a code change and redeploy every time a new roster year needed to be activated. This change allows any admin to switch the active roster from the UI.

## What steps did you take?

**Backend:**
- Created `app_settings` migration (key-value table with timestamps)
- Created `AppSetting` Objection.js model
- Added idempotent seed defaulting `active_roster_id` to `2`
- Added `GET /api/settings/active-roster` (authenticated) and `PUT /api/settings/active-roster` (admin only)
- Added `settings:edit` permission to admin role
- Mounted settings router in `index.ts`

**Frontend:**
- Created settings API client (`GetActiveRosterID`, `SetActiveRosterID`)
- Replaced `CurrentRosterID` constant with `ActiveRosterIDState` Recoil atom (fetches from API on load)
- Updated `AdminUserManagement`, `RosterSignupForm`, and `RosterSignupFormV2` to use the atom
- Added roster selector dropdown to Admin page

## How has this been tested?

- `yarn lint-fix` and `yarn style-fix` pass
- `yarn build` compiles successfully (backend + frontend)
- No linter errors in any modified files

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Deployment Notes

Backend will deploy on main. Once it is stable, deploy the front end with a tag