### PR TITLE
fix: make terraform migration check runner-safe

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,9 +66,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | rg '^packages/backend/migrations/'; then
+          CHANGED_MIGRATIONS=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- packages/backend/migrations)
+
+          if [ -n "$CHANGED_MIGRATIONS" ]; then
+            echo "Detected migration changes:"
+            echo "$CHANGED_MIGRATIONS"
             echo "run_migrations=true" >> "$GITHUB_OUTPUT"
           else
+            echo "No migration changes detected."
             echo "run_migrations=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -85,13 +90,13 @@ jobs:
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
             --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets' \
-            --output json | jq -r 'join(",")')
+            --output text | tr '\t' ',')
 
           SECURITY_GROUPS=$(aws ecs describe-services \
             --cluster "$CLUSTER_NAME" \
             --services "$SERVICE_NAME" \
             --query 'services[0].networkConfiguration.awsvpcConfiguration.securityGroups' \
-            --output json | jq -r 'join(",")')
+            --output text | tr '\t' ',')
 
           ASSIGN_PUBLIC_IP=$(aws ecs describe-services \
             --cluster "$CLUSTER_NAME" \


### PR DESCRIPTION
## Summary
- remove `rg` dependency from migration-change detection in `.github/workflows/terraform.yml`
- use `git diff --name-only ... -- packages/backend/migrations` to detect migration changes reliably
- remove `jq` dependency from ECS network extraction by using AWS CLI text output and `tr`
- add explicit logging for detected migration files (or no changes)

## Test plan
- [ ] push branch and confirm terraform workflow no longer fails with `rg: command not found`
- [ ] verify workflow logs show detected migration files when migrations are changed
- [ ] verify migration task is skipped when no migration files changed
- [ ] verify migration ECS task still runs successfully when migration files change

Made with [Cursor](https://cursor.com)