### PR TITLE
feat: active-roster year fixes and admin-managed frontend links

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
       - frontend_modules:/app/packages/frontend/node_modules
     environment:
       - POSTGRES_CONNECTION_URL=postgresql://citizix_user:S3cret@postgres:5432/citizix_db
+      - NODE_ENV=development
     command: sh -c "yarn install && yarn db-migrate && yarn db-seed"
     depends_on:
       postgres:

--- a/packages/backend/migrations/20260412000000_expand_app_settings_value_to_text.ts
+++ b/packages/backend/migrations/20260412000000_expand_app_settings_value_to_text.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('app_settings', (table) => {
+    table.text('value').notNullable().alter();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('app_settings', (table) => {
+    table.string('value').notNullable().alter();
+  });
+}

--- a/packages/backend/models/app_setting/app_setting.ts
+++ b/packages/backend/models/app_setting/app_setting.ts
@@ -16,7 +16,7 @@ export default class AppSetting extends Model {
     properties: {
       id: { type: 'integer' },
       key: { type: 'string', minLength: 1, maxLength: 255 },
-      value: { type: 'string', minLength: 1, maxLength: 255 },
+      value: { type: 'string', minLength: 1, maxLength: 2048 },
     },
   };
 }

--- a/packages/backend/routes/settings.ts
+++ b/packages/backend/routes/settings.ts
@@ -5,6 +5,12 @@ import hasPermission from '../middleware/rbac';
 
 const router: Router = express.Router();
 const ActiveRosterSettingKey = 'active_roster_id';
+const EssentialMindSharkURLSettingKey = 'essential_mindshark_url';
+const DefaultEssentialMindSharkURL = 'https://rb.gy/zmxncc';
+
+interface FrontendLinksResponse {
+  essentialMindSharkURL: string;
+}
 
 async function ensureActiveRosterSetting(): Promise<AppSetting | undefined> {
   await AppSetting.query()
@@ -17,6 +23,18 @@ async function ensureActiveRosterSetting(): Promise<AppSetting | undefined> {
     .first();
 
   return setting;
+}
+
+async function ensureFrontendLinkSetting(
+  key: string,
+  defaultValue: string,
+): Promise<AppSetting | undefined> {
+  await AppSetting.query()
+    .insert({ key, value: defaultValue })
+    .onConflict('key')
+    .ignore();
+
+  return AppSetting.query().where({ key }).first();
 }
 
 router.get('/active-roster', async (_req: Request, res: Response) => {
@@ -70,6 +88,75 @@ router.put(
       return res
         .status(500)
         .json({ error: 'Failed to update active roster setting' });
+    }
+  },
+);
+
+router.get('/frontend-links', async (_req: Request, res: Response) => {
+  try {
+    const essentialMindSharkURLSetting = await ensureFrontendLinkSetting(
+      EssentialMindSharkURLSettingKey,
+      DefaultEssentialMindSharkURL,
+    );
+
+    if (!essentialMindSharkURLSetting) {
+      return res
+        .status(404)
+        .json({ error: 'Frontend link settings not found' });
+    }
+
+    const response: FrontendLinksResponse = {
+      essentialMindSharkURL: essentialMindSharkURLSetting.value,
+    };
+
+    return res.json(response);
+  } catch (error) {
+    console.error('Error fetching frontend link settings:', error);
+    return res.status(500).json({ error: 'Failed to fetch frontend links' });
+  }
+});
+
+router.put(
+  '/frontend-links',
+  hasPermission('settings:edit'),
+  async (req: Request, res: Response) => {
+    try {
+      const { essentialMindSharkURL } = req.body as FrontendLinksResponse;
+      const normalizedEssentialMindSharkURL = essentialMindSharkURL?.trim();
+
+      if (!normalizedEssentialMindSharkURL) {
+        return res.status(400).json({
+          error: 'A valid essentialMindSharkURL is required',
+        });
+      }
+
+      try {
+        const parsedURL = new URL(normalizedEssentialMindSharkURL);
+        if (!['http:', 'https:'].includes(parsedURL.protocol)) {
+          throw new Error('Unsupported URL protocol');
+        }
+      } catch {
+        return res.status(400).json({
+          error: 'A valid essentialMindSharkURL is required',
+        });
+      }
+
+      await AppSetting.query()
+        .insert({
+          key: EssentialMindSharkURLSettingKey,
+          value: normalizedEssentialMindSharkURL,
+        })
+        .onConflict('key')
+        .merge({ value: normalizedEssentialMindSharkURL });
+
+      const response: FrontendLinksResponse = {
+        essentialMindSharkURL: normalizedEssentialMindSharkURL,
+      };
+
+      return res.json(response);
+    } catch (error) {
+      console.error('Error updating frontend link settings:', error);
+      return res.status(500).json({ error: 'Failed to update frontend links' });
     }
   },
 );

--- a/packages/backend/seeds/app-settings.ts
+++ b/packages/backend/seeds/app-settings.ts
@@ -15,4 +15,8 @@ async function upsertSetting(
 
 export async function seed(knex: Knex): Promise<void> {
   await upsertSetting(knex, { key: 'active_roster_id', value: '2' });
+  await upsertSetting(knex, {
+    key: 'essential_mindshark_url',
+    value: 'https://rb.gy/zmxncc',
+  });
 }

--- a/packages/frontend/src/api/settings/client.ts
+++ b/packages/frontend/src/api/settings/client.ts
@@ -5,6 +5,10 @@ interface ActiveRosterResponse {
   activeRosterID: number;
 }
 
+export interface FrontendLinksResponse {
+  essentialMindSharkURL: string;
+}
+
 export default class BackendSettingsClient {
   baseApiURL: string;
 
@@ -27,5 +31,24 @@ export default class BackendSettingsClient {
       defaultRequestConfig,
     );
     return data.activeRosterID;
+  }
+
+  async GetFrontendLinks(): Promise<FrontendLinksResponse> {
+    const { data } = await axios.get<FrontendLinksResponse>(
+      `${this.baseApiURL}/api/settings/frontend-links`,
+      defaultRequestConfig,
+    );
+    return data;
+  }
+
+  async SetFrontendLinks(
+    frontendLinks: FrontendLinksResponse,
+  ): Promise<FrontendLinksResponse> {
+    const { data } = await axios.put<FrontendLinksResponse>(
+      `${this.baseApiURL}/api/settings/frontend-links`,
+      frontendLinks,
+      defaultRequestConfig,
+    );
+    return data;
   }
 }

--- a/packages/frontend/src/components/RosterSignupFormV2.tsx
+++ b/packages/frontend/src/components/RosterSignupFormV2.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import {
   Box,
@@ -18,7 +18,7 @@ import {
 import { DateTimePicker } from '@mui/x-date-pickers';
 import RosterParticipant from 'backend/models/roster_participant/roster_participant';
 import { CurrentUserSignupStatus } from '../state/store';
-import { ActiveRosterIDState } from '../state/roster';
+import { ActiveRosterIDState, CurrentRosterState } from '../state/roster';
 import { getFrontendConfig } from '../config/config';
 import BackendRosterClient from '../api/roster/roster';
 
@@ -48,10 +48,6 @@ interface RosterParticipantFormData {
   agreesToPayDues: boolean;
 }
 
-const YEARS_AT_CAMP_OPTIONS = [
-  2013, 2014, 2015, 2016, 2017, 2018, 2019, 2022, 2023, 2024,
-];
-
 function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
   const [formData, setFormData] = useState<RosterParticipantFormData>({
     probabilityOfAttending: rosterParticipant.probabilityOfAttending || 0,
@@ -80,6 +76,22 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const userSignupStatus = useRecoilValue(CurrentUserSignupStatus);
   const activeRosterID = useRecoilValue(ActiveRosterIDState);
+  const currentRoster = useRecoilValue(CurrentRosterState);
+
+  const yearsAtCampOptions = useMemo(() => {
+    const firstMindSharkYear = 2013;
+    const excludedYears = new Set([2020]);
+    const lastCampYear = currentRoster.year - 1;
+
+    if (lastCampYear < firstMindSharkYear) {
+      return [];
+    }
+
+    return Array.from(
+      { length: lastCampYear - firstMindSharkYear + 1 },
+      (_, index) => firstMindSharkYear + index,
+    ).filter((year) => !excludedYears.has(year));
+  }, [currentRoster.year]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -190,9 +202,12 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
               type="number"
               label="How many years have you attended the burn? *"
               required
-              value={formData.yearsAttended || ''}
+              value={formData.yearsAttended ?? ''}
               onChange={(e) =>
-                handleChange('yearsAttended', parseInt(e.target.value, 10))
+                handleChange(
+                  'yearsAttended',
+                  e.target.value === '' ? 0 : parseInt(e.target.value, 10) || 0,
+                )
               }
             />
           </Grid>
@@ -203,7 +218,7 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
                 How many years have you camped with MindShark?
               </FormLabel>
               <FormGroup>
-                {YEARS_AT_CAMP_OPTIONS.map((year) => (
+                {yearsAtCampOptions.map((year) => (
                   <FormControlLabel
                     key={year}
                     control={

--- a/packages/frontend/src/components/RosterSignupFormV2.tsx
+++ b/packages/frontend/src/components/RosterSignupFormV2.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import {
   Box,
@@ -21,9 +21,12 @@ import { CurrentUserSignupStatus } from '../state/store';
 import { ActiveRosterIDState, CurrentRosterState } from '../state/roster';
 import { getFrontendConfig } from '../config/config';
 import BackendRosterClient from '../api/roster/roster';
+import BackendSettingsClient from '../api/settings/client';
 
 const frontendConfig = getFrontendConfig();
 const rosterClient = new BackendRosterClient(frontendConfig.BackendURL);
+const settingsClient = new BackendSettingsClient(frontendConfig.BackendURL);
+const DefaultEssentialMindSharkURL = 'https://rb.gy/zmxncc';
 
 interface Props {
   handleSuccess: () => void;
@@ -74,6 +77,9 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
     agreesToPayDues: rosterParticipant.agreesToPayDues || false,
   });
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [essentialMindSharkURL, setEssentialMindSharkURL] = useState(
+    DefaultEssentialMindSharkURL,
+  );
   const userSignupStatus = useRecoilValue(CurrentUserSignupStatus);
   const activeRosterID = useRecoilValue(ActiveRosterIDState);
   const currentRoster = useRecoilValue(CurrentRosterState);
@@ -92,6 +98,15 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
       (_, index) => firstMindSharkYear + index,
     ).filter((year) => !excludedYears.has(year));
   }, [currentRoster.year]);
+
+  useEffect(() => {
+    settingsClient
+      .GetFrontendLinks()
+      .then((links) => setEssentialMindSharkURL(links.essentialMindSharkURL))
+      .catch((error) =>
+        console.error('Failed to load frontend link settings:', error),
+      );
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -363,12 +378,12 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
                 <>
                   I have read the essential MindShark. (
                   <a
-                    href="https://rb.gy/zmxncc"
+                    href={essentialMindSharkURL}
                     target="_blank"
                     rel="noopener noreferrer"
                     style={{ color: '#1976d2', textDecoration: 'underline' }}
                   >
-                    https://rb.gy/zmxncc
+                    {essentialMindSharkURL}
                   </a>
                   ) *
                 </>

--- a/packages/frontend/src/components/shifts/ShiftDisplay.tsx
+++ b/packages/frontend/src/components/shifts/ShiftDisplay.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useRecoilValueLoadable } from 'recoil';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useRecoilValue, useRecoilValueLoadable } from 'recoil';
 import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import TableContainer from '@mui/material/TableContainer';
@@ -14,8 +14,18 @@ import {
   Typography,
 } from '@mui/material';
 import CurrentRosterScheduleState from '../../state/schedules';
+import { CurrentRosterState } from '../../state/roster';
+import BackendShiftClient from '../../api/shifts/shifts';
+import { getFrontendConfig } from '../../config/config';
 import ShiftBlock from './ShiftBlock';
 import ShiftStack from './ShiftStack';
+
+interface DayBounds {
+  start: Date;
+  end: Date;
+}
+
+const frontendConfig = getFrontendConfig();
 
 const generateTimeSlotsByInterval = (
   intervalMins: number,
@@ -42,11 +52,112 @@ const generateDailyTimeSlots = (startDay: Date, endDay: Date) => {
   return timeSlots;
 };
 
+const getDefaultDayBounds = (year: number): DayBounds => ({
+  start: new Date(year, 7, 24),
+  end: new Date(year, 8, 1),
+});
+
+const startOfDay = (date: Date) => {
+  const newDate = new Date(date);
+  newDate.setHours(0, 0, 0, 0);
+  return newDate;
+};
+
+const endOfDay = (date: Date) => {
+  const newDate = new Date(date);
+  newDate.setHours(23, 59, 59, 999);
+  return newDate;
+};
+
 export default function ShiftDisplay() {
-  const [currentDay, setCurrentDay] = useState(new Date('08/24/2024'));
+  const currentRoster = useRecoilValue(CurrentRosterState);
   const schedules = useRecoilValueLoadable(CurrentRosterScheduleState);
-  const [timeSlots, _] = useState<Date[]>(
-    generateDailyTimeSlots(new Date('08/24/2024'), new Date('09/01/2024')),
+  const shiftClient = useMemo(
+    () => new BackendShiftClient(frontendConfig.BackendURL),
+    [],
+  );
+  const defaultBounds = useMemo(
+    () => getDefaultDayBounds(currentRoster.year),
+    [currentRoster.year],
+  );
+  const scheduleIDs =
+    schedules.state === 'hasValue'
+      ? schedules.contents.map((schedule) => schedule.id)
+      : [];
+  const scheduleIDsKey = scheduleIDs.join(',');
+  const [dayBounds, setDayBounds] = useState<DayBounds>(defaultBounds);
+  const [currentDay, setCurrentDay] = useState(defaultBounds.start);
+
+  useEffect(() => {
+    setDayBounds(defaultBounds);
+    setCurrentDay(defaultBounds.start);
+  }, [defaultBounds]);
+
+  useEffect(() => {
+    const loadShiftDayBounds = async () => {
+      if (schedules.state !== 'hasValue' || scheduleIDs.length === 0) {
+        setDayBounds(defaultBounds);
+        return;
+      }
+
+      const shiftViewModelsBySchedule = await Promise.all(
+        scheduleIDs.map((scheduleID) =>
+          shiftClient.GetShiftViewModelsBySchedule(scheduleID),
+        ),
+      );
+
+      const allShifts = shiftViewModelsBySchedule.flatMap((shiftViewModels) =>
+        shiftViewModels.map((shiftViewModel) => shiftViewModel.shift),
+      );
+
+      if (allShifts.length === 0) {
+        setDayBounds(defaultBounds);
+        return;
+      }
+
+      const [firstShift, ...remainingShifts] = allShifts;
+      let minStart = new Date(firstShift.startTime);
+      let maxEnd = new Date(firstShift.endTime);
+
+      remainingShifts.forEach((shift) => {
+        const shiftStart = new Date(shift.startTime);
+        const shiftEnd = new Date(shift.endTime);
+
+        if (shiftStart < minStart) {
+          minStart = shiftStart;
+        }
+        if (shiftEnd > maxEnd) {
+          maxEnd = shiftEnd;
+        }
+      });
+
+      setDayBounds({
+        start: startOfDay(minStart),
+        end: endOfDay(maxEnd),
+      });
+    };
+
+    loadShiftDayBounds().catch((error) => {
+      console.error('Failed to load shift bounds, using fallback:', error);
+      setDayBounds(defaultBounds);
+    });
+  }, [
+    defaultBounds,
+    scheduleIDsKey,
+    scheduleIDs.length,
+    schedules.state,
+    shiftClient,
+  ]);
+
+  useEffect(() => {
+    if (currentDay < dayBounds.start || currentDay > dayBounds.end) {
+      setCurrentDay(dayBounds.start);
+    }
+  }, [currentDay, dayBounds.end, dayBounds.start]);
+
+  const timeSlots = useMemo(
+    () => generateDailyTimeSlots(dayBounds.start, dayBounds.end),
+    [dayBounds.end, dayBounds.start],
   );
 
   const handleDayChange = (change: number) => {

--- a/packages/frontend/src/components/shifts/ShiftStack.tsx
+++ b/packages/frontend/src/components/shifts/ShiftStack.tsx
@@ -48,7 +48,13 @@ export default function ShiftStack(props: Props) {
   const generateShiftBlocks = () => {
     const shiftBlocks: JSX.Element[] = [];
 
-    const lastEndTime = new Date('08/24/2024 00:00:00');
+    if (shiftViewModels.length === 0) {
+      return shiftBlocks;
+    }
+
+    const firstShift = Shift.fromJson(shiftViewModels[0].shift);
+    const lastEndTime = new Date(firstShift.startTime);
+    lastEndTime.setHours(0, 0, 0, 0);
     for (let index = 0; index < shiftViewModels.length; index += 1) {
       const shift = Shift.fromJson(shiftViewModels[index].shift);
       const differenceBetweenStartTimes =

--- a/packages/frontend/src/pages/ManageRosters.tsx
+++ b/packages/frontend/src/pages/ManageRosters.tsx
@@ -10,6 +10,7 @@ import {
   MenuItem,
   Alert,
   Button,
+  TextField,
   Table,
   TableBody,
   TableCell,
@@ -30,6 +31,7 @@ import { getFrontendConfig } from '../config/config';
 const frontendConfig = getFrontendConfig();
 const rosterClient = new BackendRosterClient(frontendConfig.BackendURL);
 const settingsClient = new BackendSettingsClient(frontendConfig.BackendURL);
+const DefaultEssentialMindSharkURL = 'https://rb.gy/zmxncc';
 
 const currentYear = new Date().getFullYear();
 
@@ -38,6 +40,9 @@ export default function ManageRosters() {
   const [activeRosterID, setActiveRosterID] =
     useRecoilState(ActiveRosterIDState);
   const [rosters, setRosters] = useState<Roster[]>([]);
+  const [essentialMindSharkURL, setEssentialMindSharkURL] = useState(
+    DefaultEssentialMindSharkURL,
+  );
   const [message, setMessage] = useState<{
     type: 'success' | 'error';
     text: string;
@@ -52,6 +57,12 @@ export default function ManageRosters() {
 
   useEffect(() => {
     rosterClient.GetAllRosters().then(setRosters).catch(console.error);
+    settingsClient
+      .GetFrontendLinks()
+      .then((links) => setEssentialMindSharkURL(links.essentialMindSharkURL))
+      .catch((error) =>
+        console.error('Failed to load frontend link settings:', error),
+      );
   }, []);
 
   const currentYearRosterExists = rosters.some(
@@ -89,6 +100,23 @@ export default function ManageRosters() {
       setMessage({
         type: 'error',
         text: `Failed to create roster: ${error}`,
+      });
+    }
+  };
+
+  const handleSaveFrontendLinks = async () => {
+    try {
+      await settingsClient.SetFrontendLinks({
+        essentialMindSharkURL,
+      });
+      setMessage({
+        type: 'success',
+        text: 'Frontend link settings updated successfully.',
+      });
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text: `Failed to update frontend links: ${error}`,
       });
     }
   };
@@ -169,6 +197,31 @@ export default function ManageRosters() {
                   </TableBody>
                 </Table>
               </TableContainer>
+            </Paper>
+          </Grid>
+          <Grid item xs={12}>
+            <Paper sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
+              <h1>Frontend Links</h1>
+              <Typography sx={{ mb: 2 }}>
+                Update links used in frontend user-facing forms.
+              </Typography>
+              <TextField
+                label="Essential MindShark URL"
+                value={essentialMindSharkURL}
+                onChange={(event) =>
+                  setEssentialMindSharkURL(event.target.value)
+                }
+                fullWidth
+                sx={{ maxWidth: 800, mb: 2 }}
+              />
+              <Button
+                variant="contained"
+                onClick={handleSaveFrontendLinks}
+                disabled={!essentialMindSharkURL.trim()}
+                sx={{ alignSelf: 'flex-start' }}
+              >
+                Save Frontend Links
+              </Button>
             </Paper>
           </Grid>
         </Grid>

--- a/packages/frontend/src/state/schedules.ts
+++ b/packages/frontend/src/state/schedules.ts
@@ -11,11 +11,8 @@ const CurrentRosterScheduleState = selector<Schedule[]>({
   key: 'currentRosterScheduleState',
   get: async ({ get }) => {
     const roster = get(CurrentRosterState);
-    console.log(
-      `we should eventually only load schedules for a specific roster ${roster.id}`,
-    );
-    const participants = await scheduleClient.GetAllSchedules();
-    return participants;
+    const schedules = await scheduleClient.GetAllSchedules();
+    return schedules.filter((schedule) => schedule.rosterID === roster.id);
   },
 });
 


### PR DESCRIPTION
## Summary
- Fix roster signup year behavior to follow the active roster year: generate MindShark camp-year options dynamically (`2013..activeRosterYear-1`) while excluding `2020`, and preserve `0` correctly for burn attendance input.
- Remove hardcoded `2024` shift timeline assumptions by deriving day bounds from loaded shift data (with active-roster-year fallback) and initializing shift stack baselines from actual shift day context.
- Scope schedules to the active roster in frontend state so roster changes propagate consistently to shift UI.
- Add admin-configurable frontend link settings backed by DB `app_settings` (`essential_mindshark_url`) with settings API endpoints and admin UI controls in Manage Rosters.
- Make docker dev startup more robust after resets by setting `NODE_ENV=development` on the `migrate` service so dev-auth seed users are reliably created.
- Add migration to expand `app_settings.value` to `text` and update model validation length to support longer URLs safely.

## Why
- Users reported roster signup year bugs (missing selectable year, incorrect zero handling) and stale hardcoded year behavior in frontend flows.
- Ops/admin workflow needed non-code updates for key user-facing links (e.g., Essential MindShark), editable by admins and persisted in DB.
- Fresh `docker-dev-reset` runs could boot into missing dev-auth users due to seed environment mismatch; startup now self-heals.

## Files changed
- `docker-compose.yaml`
- `packages/backend/migrations/20260412000000_expand_app_settings_value_to_text.ts`
- `packages/backend/models/app_setting/app_setting.ts`
- `packages/backend/routes/settings.ts`
- `packages/backend/seeds/app-settings.ts`
- `packages/frontend/src/api/settings/client.ts`
- `packages/frontend/src/components/RosterSignupFormV2.tsx`
- `packages/frontend/src/components/shifts/ShiftDisplay.tsx`
- `packages/frontend/src/components/shifts/ShiftStack.tsx`
- `packages/frontend/src/pages/ManageRosters.tsx`
- `packages/frontend/src/state/schedules.ts`

## Test plan
- [x] `yarn lint-fix`
- [x] `yarn style-fix`
- [x] `yarn build`
- [x] `make docker-dev-reset && make docker-dev` boots with migration/seed flow
- [x] Verify backend health endpoint responds: `GET /api/health`
- [x] Verify frontend serves on `http://localhost:3000`
- [x] Verify dev auth endpoints are available in docker-dev env (`/api/auth/dev/status`, `/api/auth/dev/login/admin`)
- [x] Manual UI: roster signup shows dynamic years through `activeRosterYear - 1` excluding `2020`
- [x] Manual UI: roster signup `yearsAttended` displays and preserves `0`
- [x] Manual UI: shift timeline is no longer pinned to 2024 and aligns with active roster schedule data
- [x] Manual UI: switching active roster updates year-sensitive signup/shift behavior after reload
- [x] Manual UI: Manage Roster create flow remains calendar-year based (intentional)
- [x] Manual UI: admin updates Essential MindShark URL in Manage Rosters and signup form reflects saved value
