### PR TITLE
fix(ci): make migration-change detection robust to shallow clone & edge cases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -138,7 +140,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          CHANGED_MIGRATIONS=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- packages/backend/migrations)
+          BEFORE="${{ github.event.before }}"
+          SHA="${{ github.sha }}"
+          ZERO_SHA="0000000000000000000000000000000000000000"
+
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO_SHA" ]; then
+            echo "No 'before' commit (initial push). Running migrations as a safe default."
+            echo "run_migrations=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "Before commit $BEFORE not reachable (force-push?). Running migrations as a safe default."
+            echo "run_migrations=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_MIGRATIONS=$(git diff --name-only "$BEFORE" "$SHA" -- packages/backend/migrations)
 
           if [ -n "$CHANGED_MIGRATIONS" ]; then
             echo "Detected migration changes:"


### PR DESCRIPTION
## Description

Fixes the `Detect migration file changes` step in the `Deploy` workflow, which was aborting with `fatal: bad object <sha>` (exit 128) and blocking deploys.

Two changes, both confined to the `terraform` job in `.github/workflows/deploy.yml`:

1. Set `fetch-depth: 0` on the `actions/checkout@v4` step so the previous commit is reachable.
2. Defensively handle two edge cases before diffing:
   - `github.event.before` is the zero-SHA (initial push / branch recreate) -> run migrations.
   - `github.event.before` is unreachable (force-push history rewrite) -> run migrations.

Other jobs (`build-app`, `build-migration`) keep the default shallow clone.

## Motivation and Context

CI run [25075820738](https://github.com/campmindshark/people-manager/actions/runs/25075820738) failed at the migration-detection step:

\`\`\`
git diff --name-only \"731d330...\" \"f204f51...\" -- packages/backend/migrations
fatal: bad object 731d330fbd0e71fff7d467ac7d02c86966023686
\`\`\`

Root cause: \`actions/checkout@v4\` defaults to \`fetch-depth: 1\`, so the previous commit isn't in the runner's local git history and \`git diff\` cannot resolve it. Every subsequent push to \`main\` would fail the same way.

## What steps did you take?

- Reproduced the failure from the CI logs and confirmed both SHAs exist in the remote, ruling out anything other than shallow clone.
- Evaluated alternatives (`dorny/paths-filter`, lazy `git fetch`, GitHub Compare API) and selected the minimal-surface fix: full-depth checkout plus defensive guards.
- Verified \"run on uncertainty\" is safe: Knex's \`knex_migrations\` table makes re-running idempotent; missing a real migration would break production.

## How has this been tested?

- Replayed the diff locally for the failing push:
  \`git diff --name-only 731d330 f204f51 -- packages/backend/migrations\` returns empty (PR #53 only changed CI/Docker), so the fixed step would correctly set \`run_migrations=false\` and skip the ECS task.
- Static review of the bash: \`set -euo pipefail\` preserved; \`set -e\` does not trip on \`if ! cmd\` (negated test contexts are exempt); both refs are GitHub-supplied SHAs so quoting is safe.
- No linter errors on \`.github/workflows/deploy.yml\`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Made with [Cursor](https://cursor.com)