### PR TITLE
feat: Integrate burn date information into RosterSignupFormV2

### DIFF
--- a/packages/backend/utils/burnDates.ts
+++ b/packages/backend/utils/burnDates.ts
@@ -1,0 +1,120 @@
+import { DateTime } from 'luxon';
+
+// Burning Man takes place in Black Rock City, Nevada (Pacific Time).
+// Anchoring all calendar boundaries to this zone prevents off-by-one
+// errors when consumers convert to/from UTC.
+export const BM_TIMEZONE = 'America/Los_Angeles';
+
+export interface BurnDates {
+  // Monday of build week — the earliest day a participant can plausibly
+  // arrive on Early Arrival.
+  earlyArrivalStart: Date;
+  // Sunday gates open (general public arrival).
+  gatesOpen: Date;
+  // Wednesday of event week — the latest day arrival is allowed.
+  eventWednesday: Date;
+  // Saturday Man burn.
+  manBurn: Date;
+  // Sunday Temple burn.
+  templeBurn: Date;
+  // Monday Labor Day (event ends).
+  laborDay: Date;
+}
+
+export interface DateTimePickerBounds {
+  // Start of EA Monday (00:00:00 PT).
+  arrivalMin: Date;
+  // End of event Wednesday (23:59:59.999 PT).
+  arrivalMax: Date;
+  // End of (Man Saturday + 3 days) (23:59:59.999 PT).
+  departureMaxEnd: Date;
+}
+
+// Returns the first Monday of September in BM_TIMEZONE for the given year.
+// Burning Man traditionally ends on US Labor Day, which is the first Monday
+// of September.
+export function getLaborDay(year: number): DateTime {
+  const sept1 = DateTime.fromObject(
+    { year, month: 9, day: 1 },
+    { zone: BM_TIMEZONE },
+  );
+  // Luxon weekday: 1 = Monday, ..., 7 = Sunday.
+  const offsetToMonday = (1 - sept1.weekday + 7) % 7;
+  return sept1.plus({ days: offsetToMonday }).startOf('day');
+}
+
+// Returns the canonical Burning Man calendar dates for a given roster year,
+// each anchored at start-of-day Pacific Time. Derived from the Labor Day
+// rule that has held since the 1990s:
+//   gatesOpen   = laborDay - 8 days (Sunday)
+//   manBurn     = laborDay - 2 days (Saturday)
+//   templeBurn  = laborDay - 1 day  (Sunday)
+//   earlyArrivalStart = gatesOpen - 6 days (Monday)
+//   eventWednesday    = gatesOpen + 3 days (Wednesday)
+export function getBurnDates(rosterYear: number): BurnDates {
+  const laborDay = getLaborDay(rosterYear);
+  const gatesOpen = laborDay.minus({ days: 8 });
+  const earlyArrivalStart = gatesOpen.minus({ days: 6 });
+  const eventWednesday = gatesOpen.plus({ days: 3 });
+  const manBurn = laborDay.minus({ days: 2 });
+  const templeBurn = laborDay.minus({ days: 1 });
+
+  return {
+    earlyArrivalStart: earlyArrivalStart.toJSDate(),
+    gatesOpen: gatesOpen.toJSDate(),
+    eventWednesday: eventWednesday.toJSDate(),
+    manBurn: manBurn.toJSDate(),
+    templeBurn: templeBurn.toJSDate(),
+    laborDay: laborDay.toJSDate(),
+  };
+}
+
+// Returns picker boundaries (JS Date) for use as MUI DateTimePicker
+// minDateTime / maxDateTime props. Maxes are end-of-day so the entire
+// Pacific calendar day is selectable.
+export function getDateTimePickerBounds(
+  rosterYear: number,
+): DateTimePickerBounds {
+  const laborDay = getLaborDay(rosterYear);
+  const gatesOpen = laborDay.minus({ days: 8 });
+  const earlyArrivalStart = gatesOpen.minus({ days: 6 });
+  const eventWednesday = gatesOpen.plus({ days: 3 });
+  const manBurn = laborDay.minus({ days: 2 });
+  // +3 days past Man Saturday is the latest allowed departure.
+  const departureMaxDay = manBurn.plus({ days: 3 });
+
+  return {
+    arrivalMin: earlyArrivalStart.startOf('day').toJSDate(),
+    arrivalMax: eventWednesday.endOf('day').toJSDate(),
+    departureMaxEnd: departureMaxDay.endOf('day').toJSDate(),
+  };
+}
+
+// Ordinal suffix for English day-of-month: 1st, 2nd, 3rd, 4th, ...
+// Handles the 11th/12th/13th irregulars correctly (they take "th",
+// not "st"/"nd"/"rd").
+function ordinalSuffix(day: number): string {
+  const lastTwo = day % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) {
+    return 'th';
+  }
+  switch (day % 10) {
+    case 1:
+      return 'st';
+    case 2:
+      return 'nd';
+    case 3:
+      return 'rd';
+    default:
+      return 'th';
+  }
+}
+
+// Formats a Date as a human-friendly burn-date label such as
+// "Sunday, August 30th", always rendered in BM_TIMEZONE so the weekday
+// and day number match what attendees see on the playa.
+export function formatBurnDateLabel(date: Date): string {
+  const dt = DateTime.fromJSDate(date).setZone(BM_TIMEZONE);
+  const weekdayMonth = dt.toFormat('cccc, LLLL');
+  return `${weekdayMonth} ${dt.day}${ordinalSuffix(dt.day)}`;
+}

--- a/packages/frontend/src/components/RosterSignupFormV2.tsx
+++ b/packages/frontend/src/components/RosterSignupFormV2.tsx
@@ -18,6 +18,11 @@ import {
 import { DateTimePicker } from '@mui/x-date-pickers';
 import RosterParticipant from 'backend/models/roster_participant/roster_participant';
 import { getCampYearsOptions } from 'backend/utils/campYears';
+import {
+  formatBurnDateLabel,
+  getBurnDates,
+  getDateTimePickerBounds,
+} from 'backend/utils/burnDates';
 import { CurrentUserSignupStatus } from '../state/store';
 import { ActiveRosterIDState, CurrentRosterState } from '../state/roster';
 import { getFrontendConfig } from '../config/config';
@@ -89,6 +94,17 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
     () => getCampYearsOptions(currentRoster.year),
     [currentRoster.year],
   );
+
+  const burnInfo = useMemo(() => {
+    const dates = getBurnDates(currentRoster.year);
+    const bounds = getDateTimePickerBounds(currentRoster.year);
+    return {
+      bounds,
+      gatesLabel: formatBurnDateLabel(dates.gatesOpen),
+      eaLabel: formatBurnDateLabel(dates.earlyArrivalStart),
+      templeLabel: formatBurnDateLabel(dates.templeBurn),
+    };
+  }, [currentRoster.year]);
 
   useEffect(() => {
     settingsClient
@@ -259,11 +275,19 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
                 handleChange('estimatedArrivalDate', date)
               }
               timezone="America/Los_Angeles"
+              minDateTime={burnInfo.bounds.arrivalMin}
+              maxDateTime={burnInfo.bounds.arrivalMax}
               slotProps={{
                 textField: {
                   fullWidth: true,
                   required: true,
-                  helperText: 'Gates open Sunday, August 24th',
+                  helperText: (
+                    <>
+                      Gates open {burnInfo.gatesLabel}
+                      <br />
+                      EA begins {burnInfo.eaLabel}
+                    </>
+                  ),
                 },
               }}
             />
@@ -281,11 +305,15 @@ function RosterSignupFormV2({ handleSuccess, rosterParticipant }: Props) {
                 handleChange('estimatedDepartureDate', date)
               }
               timezone="America/Los_Angeles"
+              minDateTime={
+                formData.estimatedArrivalDate ?? burnInfo.bounds.arrivalMin
+              }
+              maxDateTime={burnInfo.bounds.departureMaxEnd}
               slotProps={{
                 textField: {
                   fullWidth: true,
                   required: true,
-                  helperText: 'Temple burns Sunday, August 31st',
+                  helperText: `Temple burns ${burnInfo.templeLabel}`,
                 },
               }}
             />

--- a/packages/frontend/src/utils/burnDates.test.ts
+++ b/packages/frontend/src/utils/burnDates.test.ts
@@ -1,0 +1,183 @@
+import { DateTime } from 'luxon';
+import {
+  BM_TIMEZONE,
+  formatBurnDateLabel,
+  getBurnDates,
+  getDateTimePickerBounds,
+  getLaborDay,
+} from 'backend/utils/burnDates';
+
+const formatPT = (date: Date, fmt: string): string =>
+  DateTime.fromJSDate(date).setZone(BM_TIMEZONE).toFormat(fmt);
+
+const isoPT = (date: Date): string =>
+  DateTime.fromJSDate(date).setZone(BM_TIMEZONE).toISO() ?? '';
+
+describe('getLaborDay', () => {
+  it('returns Sept 2 2024 (Sept 1 was a Sunday)', () => {
+    const ld = getLaborDay(2024);
+    expect(ld.toISODate()).toBe('2024-09-02');
+    expect(ld.weekdayLong).toBe('Monday');
+  });
+
+  it('returns Sept 1 2025 (Sept 1 was a Monday)', () => {
+    const ld = getLaborDay(2025);
+    expect(ld.toISODate()).toBe('2025-09-01');
+    expect(ld.weekdayLong).toBe('Monday');
+  });
+
+  it('returns Sept 7 2026 (Sept 1 is a Tuesday)', () => {
+    const ld = getLaborDay(2026);
+    expect(ld.toISODate()).toBe('2026-09-07');
+    expect(ld.weekdayLong).toBe('Monday');
+  });
+
+  it('returns Sept 6 2027 (Sept 1 is a Wednesday)', () => {
+    const ld = getLaborDay(2027);
+    expect(ld.toISODate()).toBe('2027-09-06');
+    expect(ld.weekdayLong).toBe('Monday');
+  });
+
+  it('returns Sept 4 2028 (Sept 1 is a Friday)', () => {
+    const ld = getLaborDay(2028);
+    expect(ld.toISODate()).toBe('2028-09-04');
+    expect(ld.weekdayLong).toBe('Monday');
+  });
+});
+
+describe('getBurnDates', () => {
+  it('matches the 2025 strings used by the legacy hardcoded helper text', () => {
+    const dates = getBurnDates(2025);
+    expect(formatPT(dates.gatesOpen, 'cccc, yyyy-LL-dd')).toBe(
+      'Sunday, 2025-08-24',
+    );
+    expect(formatPT(dates.templeBurn, 'cccc, yyyy-LL-dd')).toBe(
+      'Sunday, 2025-08-31',
+    );
+    expect(formatPT(dates.manBurn, 'cccc, yyyy-LL-dd')).toBe(
+      'Saturday, 2025-08-30',
+    );
+    expect(formatPT(dates.earlyArrivalStart, 'cccc, yyyy-LL-dd')).toBe(
+      'Monday, 2025-08-18',
+    );
+    expect(formatPT(dates.eventWednesday, 'cccc, yyyy-LL-dd')).toBe(
+      'Wednesday, 2025-08-27',
+    );
+    expect(formatPT(dates.laborDay, 'cccc, yyyy-LL-dd')).toBe(
+      'Monday, 2025-09-01',
+    );
+  });
+
+  it('matches the official Burning Man 2026 schedule', () => {
+    const dates = getBurnDates(2026);
+    expect(formatPT(dates.gatesOpen, 'cccc, yyyy-LL-dd')).toBe(
+      'Sunday, 2026-08-30',
+    );
+    expect(formatPT(dates.earlyArrivalStart, 'cccc, yyyy-LL-dd')).toBe(
+      'Monday, 2026-08-24',
+    );
+    expect(formatPT(dates.eventWednesday, 'cccc, yyyy-LL-dd')).toBe(
+      'Wednesday, 2026-09-02',
+    );
+    expect(formatPT(dates.manBurn, 'cccc, yyyy-LL-dd')).toBe(
+      'Saturday, 2026-09-05',
+    );
+    expect(formatPT(dates.templeBurn, 'cccc, yyyy-LL-dd')).toBe(
+      'Sunday, 2026-09-06',
+    );
+    expect(formatPT(dates.laborDay, 'cccc, yyyy-LL-dd')).toBe(
+      'Monday, 2026-09-07',
+    );
+  });
+
+  it('anchors every date at midnight Pacific Time (no off-by-one drift)', () => {
+    const dates = getBurnDates(2026);
+    Object.values(dates).forEach((date) => {
+      expect(formatPT(date, 'HH:mm:ss.SSS')).toBe('00:00:00.000');
+    });
+  });
+
+  it('returns dates that are always in PDT (-07:00) for the burn week', () => {
+    const dates = getBurnDates(2026);
+    Object.values(dates).forEach((date) => {
+      expect(isoPT(date)).toMatch(/-07:00$/);
+    });
+  });
+});
+
+describe('getDateTimePickerBounds', () => {
+  it('arrivalMin is start of EA Monday Pacific (2026)', () => {
+    const bounds = getDateTimePickerBounds(2026);
+    expect(formatPT(bounds.arrivalMin, 'yyyy-LL-dd HH:mm:ss.SSS ZZ')).toBe(
+      '2026-08-24 00:00:00.000 -07:00',
+    );
+  });
+
+  it('arrivalMax is end of event Wednesday Pacific (2026)', () => {
+    const bounds = getDateTimePickerBounds(2026);
+    expect(formatPT(bounds.arrivalMax, 'yyyy-LL-dd HH:mm:ss.SSS ZZ')).toBe(
+      '2026-09-02 23:59:59.999 -07:00',
+    );
+  });
+
+  it('departureMaxEnd is end of (Man Saturday + 3 days) Pacific (2026)', () => {
+    const bounds = getDateTimePickerBounds(2026);
+    expect(formatPT(bounds.departureMaxEnd, 'yyyy-LL-dd HH:mm:ss.SSS ZZ')).toBe(
+      '2026-09-08 23:59:59.999 -07:00',
+    );
+  });
+
+  it('arrivalMin precedes arrivalMax which precedes departureMaxEnd', () => {
+    const bounds = getDateTimePickerBounds(2026);
+    expect(bounds.arrivalMin.getTime()).toBeLessThan(
+      bounds.arrivalMax.getTime(),
+    );
+    expect(bounds.arrivalMax.getTime()).toBeLessThan(
+      bounds.departureMaxEnd.getTime(),
+    );
+  });
+});
+
+describe('formatBurnDateLabel', () => {
+  const labelForPTDay = (year: number, month: number, day: number): string => {
+    const dt = DateTime.fromObject(
+      { year, month, day },
+      { zone: BM_TIMEZONE },
+    ).startOf('day');
+    return formatBurnDateLabel(dt.toJSDate());
+  };
+
+  it('formats as "Weekday, Month Nth"', () => {
+    expect(labelForPTDay(2026, 8, 30)).toBe('Sunday, August 30th');
+    expect(labelForPTDay(2026, 8, 24)).toBe('Monday, August 24th');
+    expect(labelForPTDay(2026, 9, 6)).toBe('Sunday, September 6th');
+  });
+
+  it('uses st/nd/rd for 1, 2, 3', () => {
+    expect(labelForPTDay(2026, 9, 1)).toBe('Tuesday, September 1st');
+    expect(labelForPTDay(2026, 9, 2)).toBe('Wednesday, September 2nd');
+    expect(labelForPTDay(2026, 9, 3)).toBe('Thursday, September 3rd');
+  });
+
+  it('uses th for 4-10', () => {
+    expect(labelForPTDay(2026, 9, 4)).toBe('Friday, September 4th');
+    expect(labelForPTDay(2026, 9, 10)).toBe('Thursday, September 10th');
+  });
+
+  it('uses th for the 11/12/13 irregulars (not st/nd/rd)', () => {
+    expect(labelForPTDay(2026, 9, 11)).toBe('Friday, September 11th');
+    expect(labelForPTDay(2026, 9, 12)).toBe('Saturday, September 12th');
+    expect(labelForPTDay(2026, 9, 13)).toBe('Sunday, September 13th');
+  });
+
+  it('uses st/nd/rd for 21, 22, 23', () => {
+    expect(labelForPTDay(2026, 8, 21)).toBe('Friday, August 21st');
+    expect(labelForPTDay(2026, 8, 22)).toBe('Saturday, August 22nd');
+    expect(labelForPTDay(2026, 8, 23)).toBe('Sunday, August 23rd');
+  });
+
+  it('uses th for end-of-month', () => {
+    expect(labelForPTDay(2026, 8, 30)).toBe('Sunday, August 30th');
+    expect(labelForPTDay(2026, 8, 31)).toBe('Monday, August 31st');
+  });
+});


### PR DESCRIPTION
These changes improve the clarity and usability of the signup form for participants.

<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added functionality to retrieve and format burn date information for the current roster year.
* Updated the estimated arrival and departure date pickers to utilize burn date bounds and display relevant helper text.
* Enhanced user experience by dynamically showing gates open and early arrival dates based on the current roster year.
* fixed timezone to BM timezone 

## Motivation and Context

Previously users could select any date and any year, making the information stored unhelpful.


## What steps did you take?

Added burnDate.ts util to determine labor day, burn week and EA dates based.


## How has this been tested?

Added relevant unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
